### PR TITLE
HC-378 create separate pele client repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,141 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+downloads/
+eggs/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.cache
+nosetests.xml
+coverage.xml
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# db
+data/
+migrations/
+
+# coverage
+tmp/
+
+# settings
+settings.cfg
+
+# environments
+venv
+node_env
+
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and WebStorm
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+.idea
+.idea/
+
+# User-specific stuff
+.idea/**/workspace.xml
+.idea/**/tasks.xml
+.idea/**/usage.statistics.xml
+.idea/**/dictionaries
+.idea/**/shelf
+
+# Generated files
+.idea/**/contentModel.xml
+
+# Sensitive or high-churn files
+.idea/**/dataSources/
+.idea/**/dataSources.ids
+.idea/**/dataSources.local.xml
+.idea/**/sqlDataSources.xml
+.idea/**/dynamic.xml
+.idea/**/uiDesigner.xml
+.idea/**/dbnavigator.xml
+
+# Gradle
+.idea/**/gradle.xml
+.idea/**/libraries
+
+# Gradle and Maven with auto-import
+# When using Gradle or Maven with auto-import, you should exclude module files,
+# since they will be recreated, and may cause churn.  Uncomment if using
+# auto-import.
+# .idea/artifacts
+# .idea/compiler.xml
+# .idea/jarRepositories.xml
+# .idea/modules.xml
+# .idea/*.iml
+# .idea/modules
+# *.iml
+# *.ipr
+
+# CMake
+cmake-build-*/
+
+# Mongo Explorer plugin
+.idea/**/mongoSettings.xml
+
+# File-based project format
+*.iws
+
+# IntelliJ
+out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Cursive Clojure plugin
+.idea/replstate.xml
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+
+# Editor-based Rest Client
+.idea/httpRequests
+
+# Android studio 3.1+ serialized cache file
+.idea/caches/build_file_checksums.ser

--- a/README.md
+++ b/README.md
@@ -1,61 +1,51 @@
-# [REPO NAME]
-> Single sentence describing the purpose of your repo
+# pele_client
+REST-based class for issuing Pele requests (HySDS Datasets API)
 
-[Workflow status badges - see [docs](https://docs.github.com/en/actions/managing-workflow-runs/adding-a-workflow-status-badge)]
+### Installation
+First, gdal (osgeo) must be installed via conda using the conda-forge channel:
+```
+conda install -c requirements.txt.forge
+```
+then the client is installed:
+``` 
+python setup.py install
+```
 
-More detailed description of your repository here
+### Examples
+To have the requests client automatically renew the client session upon expiration, ensure your login creds are set in your .netrc file, e.g.
+```
+bash
+cat ~/.netrc
+# machine localhost login koa@test.com password test
+# macdef init
 
-![](header.png) [Screenshot of your software, if applicable]
 
-## Build Instructions
+```
+The Pele requests client will then use your creds to attain an API token to use for subsequent API calls. When the token expires, the client will refresh the token automatically:
+```
+python
+from pele_client.client import PeleRequests
 
-[Modify as/if needed]
+base_url = "http://localhost:8877/api/v0.1"
 
-e.g.
+# instantiate PeleRequests object
+pr = PeleRequests(base_url)
 
-Built using the ARIA HySDS Jenkins Continuous Integration (CI) pipeline.
+# now use like requests module (`request()`, `get()`, `head()`, `post()`, `put()`, `delete()`, `patch()`)
+r = pr.get(base_url + '/test/echo', params={'echo_str': 'hello world'})
 
-More information about this process can be found [here](https://hysds-core.atlassian.net/wiki/spaces/HYS/pages/455114757/Deploy+PGE+s+onto+Cluster)
+```
+The utility function ```getPeleExtentFromOGRFile``` extracts the bounding box encompassing the layer/features in the given OGR-compliant file. If the file is multi-layer, an
+optional layer name can be specified, otherwise the first/top layer is used by default. The format of the returned extent is compatible with Pele geospatial searches.
+```
+from pele_client.client import PeleRequests, getPeleExtentFromOGRFile
 
-## Run Instructions
+pr = PeleRequests('https://100.64.122.98/pele/api/v0.1', verify=False)
 
-[Modify as/if needed and add any customizations for your code]
+extent = getPeleExtentFromOGRFile('/home/wasabi/ucayali_boundary.geojson', 'ucayali_boundary')
 
-e.g.
+response = pr.post(base_url + '/pele/dataset/L2_L_GSLC/dataset_ids', json = { 'polygon' : extent })
+response_json = response.json()
 
-You may run your customized PGE via two methods that are documented below:
-- An [on-demand (one-time) job](https://hysds-core.atlassian.net/wiki/spaces/HYS/pages/378601499/Submit+an+On-Demand+Job+in+Facet+Search)
-- [Create a trigger rule](https://hysds-core.atlassian.net/wiki/spaces/HYS/pages/442728660/Create+Edit+Delete+Trigger+Rules) to invoke your PGE based on conditions
-
-## Release History
-
-* 0.2.1
-    * CHANGE: Update docs (module code remains unchanged)
-* 0.2.0
-    * CHANGE: Remove `setDefaultXYZ()`
-    * ADD: Add `init()`
-* 0.1.1
-    * FIX: Crash when calling `baz()` (Thanks @GenerousContributorName!)
-* 0.1.0
-    * The first proper release
-    * CHANGE: Rename `foo()` to `bar()`
-* 0.0.1
-    * Work in progress
-
-## Frequently Asked Questions (FAQ)
-
-1. Question 1
-   - Answer to question 1
-2. Question 2
-   - Answer to question 2
-
-## Contributing
-
-1. Create an GitHub issue ticket desrcribing what changes you need (e.g. issue-1)
-2. Fork this repo
-3. Make your modifications in your own fork
-4. Make a pull-request in this repo with the code in your fork and tag the repo owner / largest contributor as a reviewer
-
-## Support
-
-Any specific contact information regarding leadership / maintenance of this repository
+datasets = ressponse_json['dataset_ids']
+```

--- a/pele_client/client.py
+++ b/pele_client/client.py
@@ -1,0 +1,128 @@
+from builtins import object
+import requests
+import time
+from osgeo import ogr
+
+
+# Utility function that returns the extent for the features in the 
+# given file (and optionally named layer), returned in the format 
+# compatible with pele/ES geospatial searches.
+#
+def getPeleExtentFromOGRFile(ogrFileName, layerName=None):
+    result = None
+
+    # Note: tried using 'ogr.UseExceptions()' to have Open throw an exception on failure but
+    # it wouldn't do it...
+    dataset = ogr.Open(ogrFileName, update=0)
+
+    if dataset is None:
+        raise RuntimeError('Unable to open file: {}. It either does not exist or is not a supported type'.format(ogrFileName))
+        
+    layer = None
+    if layerName is not None:
+        layer = dataset.GetLayerByName(layerName)
+    else:
+        # no named layer
+        if dataset.GetLayerCount() > 1:
+            print('No layer name specified for a multi-layer file {}, using top layer.'.format(ogrFileName))
+        layer = dataset.GetLayer(0)
+
+    if layer is None:
+        if layerName is not None:
+            raise RuntimeError('Unable to extract layer: {} from file: {}'.format(layerName,ogrFileName))
+        else:
+            raise RuntimeError('Unable to extract top layer from file: {}'.format(ogrFileName))
+
+    extent = layer.GetExtent()
+    bottom = extent[0]
+    top = extent[1]
+    left = extent[2]
+    right = extent[3]
+
+    result = []
+    result.append([bottom, left])
+    result.append([bottom, right])
+    result.append([top, right])
+    result.append([top, left])
+    result.append([bottom, left])
+
+    # conform to filter format
+    result = [result]
+
+    # dereference dataset to close the datasource - https://gdal.org/api/python_gotchas.html
+    dataset = None
+
+    return result
+    
+
+class PeleRequests(object):
+    def __init__(self, base_url, verify=True, auth=True):
+        """
+        :param base_url: Pele's Rest API base endpoint
+        :param verify: verify requests with SSL certs
+        :param auth: (boolean) authenticate requests (set to True if Pele's Rest API server is authenticated)
+        """
+        self.auth = auth
+        self.session = requests.session()
+        self.base_url = base_url 
+        self.verify = verify 
+        self.token = None
+        if self.auth:
+            self._set_token()
+
+    def _set_token(self):
+        r = self.session.post(self.base_url + '/login', verify=self.verify)
+        if r.status_code == 429 and 'Retry-After' in r.headers:
+            sleep_time = float(r.headers['Retry-After'])
+            print("hit rate limit. sleeping for {} seconds".format(sleep_time))
+            time.sleep(sleep_time)
+            r = self.session.post(self.base_url + '/login', verify=self.verify)
+        r.raise_for_status()
+        self.token = r.json()['token']
+
+    def _decorator(f):
+        def wrapper(self, *args, **kwargs):
+            if 'verify' not in kwargs:
+                kwargs['verify'] = self.verify
+            if self.auth is False:
+                r = f(self, *args, **kwargs)
+            else:
+                if 'X-API-KEY' not in kwargs.get('headers', {}):
+                    kwargs.setdefault('headers', {})['X-API-KEY'] = self.token
+                r = f(self, *args, **kwargs)
+                if r.status_code == 401:
+                    self._set_token()  # refresh token
+                    kwargs['headers']['X-API-KEY'] = self.token
+                    r = f(self, *args, **kwargs)
+            return r
+        return wrapper
+
+    @_decorator
+    def request(self, *args, **kwargs):
+        return self.session.request(*args, **kwargs)
+
+    @_decorator
+    def head(self, *args, **kwargs):
+        return self.session.head(*args, **kwargs)
+
+    @_decorator
+    def get(self, *args, **kwargs):
+        return self.session.get(*args, **kwargs)
+
+    @_decorator
+    def post(self, *args, **kwargs):
+        return self.session.post(*args, **kwargs)
+
+    @_decorator
+    def put(self, *args, **kwargs):
+        return self.session.put(*args, **kwargs)
+
+    @_decorator
+    def patch(self, *args, **kwargs):
+        return self.session.patch(*args, **kwargs)
+
+    @_decorator
+    def delete(self, *args, **kwargs):
+        return self.session.delete(*args, **kwargs)
+
+    _decorator = staticmethod(_decorator)

--- a/requirements.txt.forge
+++ b/requirements.txt.forge
@@ -1,0 +1,2 @@
+gdal
+requests

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,14 @@
+from setuptools import setup, find_packages
+
+setup(
+    name='pele_client',
+    version='1.0.3',
+    long_description='Client for REST API for HySDS Datasets',
+    packages=find_packages(),
+    include_package_data=True,
+    zip_safe=False,
+    # Note: gdal must be conda installed from conda-forge.
+    install_requires=[
+        'requests',
+    ]
+)


### PR DESCRIPTION
Extracted client.py from pele repo, created new setup.py and added a requirements.txt.forge for gdal to be installed via conda (mentioned in README).

This also incorporates the addition of getPeleExtentFromOGRFile() helper function (HC-377). Lemme know if this should be incorporated in a separate PR.